### PR TITLE
chore: add thread safety to validator

### DIFF
--- a/LivrDemo/LivrDemo.xcodeproj/project.pbxproj
+++ b/LivrDemo/LivrDemo.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-LivrDemo/Pods-LivrDemo-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-LivrDemo/Pods-LivrDemo-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Livr/Livr.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -179,7 +179,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LivrDemo/Pods-LivrDemo-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-LivrDemo/Pods-LivrDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		808C00F815CDF2E60057D337 /* [CP] Check Pods Manifest.lock */ = {

--- a/LivrDemo/Podfile.lock
+++ b/LivrDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Livr (1.0.1)
+  - Livr (1.0.4)
 
 DEPENDENCIES:
   - Livr (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Livr: b6c6eb8075a725e30c74e38a9f3a82465f22f193
+  Livr: e2a86dfdd1c7740e46a81ccd4adacce6c43bee3d
 
 PODFILE CHECKSUM: 9c555a7c3d7a91cc2414b97dc818cde30e44efce
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1


### PR DESCRIPTION
### Why?
To turn the validator into thread safe in read and write operations

### Changes
- Control access to all validator properties with sync reads and async with barrier writes
- Update CocoaPods to 1.6.1

### Tests 
All tests keep passing

### Issue #34 